### PR TITLE
Updates documentation to reflect brand change

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 # Suga Documentation
 
-Documentation for [Suga](https://makesuga.com), the platform for building and deploying cloud-native applications.
+Documentation for [Suga](https://addsuga.com), the platform for building and deploying cloud-native applications.
 
 ## 📚 Live Documentation
 
-Visit [docs.makesuga.com](https://docs.makesuga.com) to view the live documentation.
+Visit [docs.addsuga.com](https://docs.addsuga.com) to view the live documentation.
 
 ## 🚀 Local Development
 
@@ -63,12 +63,12 @@ docs/
 ## 🤝 Support
 
 - **Issues**: [GitHub Issues](https://github.com/nitrictech/suga/issues)
-- **Email**: [support@makesuga.com](mailto:support@makesuga.com)
-- **Dashboard**: [app.makesuga.com](https://app.makesuga.com)
+- **Email**: [support@addsuga.com](mailto:support@addsuga.com)
+- **Dashboard**: [app.addsuga.com](https://app.addsuga.com)
 
 ## 🔗 Links
 
-- [Suga Platform](https://makesuga.com)
+- [Suga Platform](https://addsuga.com)
 - [GitHub](https://github.com/nitrictech/suga)
 - [X](https://x.com/sugasrc)
 - [LinkedIn](https://www.linkedin.com/company/nitrictech)

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -19,7 +19,7 @@ description: "Install the Suga CLI"
   </Tab>
   <Tab title="Linux">
     ```bash
-    curl -sSL https://makesuga.com/install.sh | sh
+    curl -sSL https://addsuga.com/install.sh | sh
     ```
   </Tab>
 </Tabs>
@@ -45,7 +45,7 @@ suga --version
   </Tab>
   <Tab title="Linux">
     ```bash
-    curl -sSL https://makesuga.com/install.sh | sh
+    curl -sSL https://addsuga.com/install.sh | sh
     ```
   </Tab>
 </Tabs>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,7 +60,7 @@
       "anchors": [
         {
           "anchor": "Website",
-          "href": "https://makesuga.com",
+          "href": "https://addsuga.com",
           "icon": "globe"
         },
         {
@@ -79,13 +79,13 @@
     "links": [
       {
         "label": "Support",
-        "href": "mailto:support@makesuga.com"
+        "href": "mailto:support@addsuga.com"
       }
     ],
     "primary": {
       "type": "button",
       "label": "Get Started",
-      "href": "https://app.makesuga.com"
+      "href": "https://app.addsuga.com"
     }
   },
   "contextual": {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -136,7 +136,7 @@ Deploy your first application on the Suga platform in just a few steps.
     ⚡ Suga v1.0.0
        - App: my-first-app
        - Addr: http://localhost:50051
-       - Dashboard: https://app.makesuga.com/dev
+       - Dashboard: https://app.addsuga.com/dev
     
     Services
     
@@ -321,5 +321,5 @@ Deploy your first application on the Suga platform in just a few steps.
 </CardGroup>
 
 <Note>
-  **Need help?** Contact [support@makesuga.com](mailto:support@makesuga.com) or check our [GitHub](https://github.com/nitrictech/suga).
+  **Need help?** Contact [support@addsuga.com](mailto:support@addsuga.com) or check our [GitHub](https://github.com/nitrictech/suga).
 </Note>


### PR DESCRIPTION
Updates all instances of "makesuga.com" to "addsuga.com"
in the documentation to reflect the new branding. This
includes links in the installation guide, website references,
support email addresses, and dashboard links.
