### PR TITLE
fix(cli): Avoids shadowing 'suga' import from Pypi

### DIFF
--- a/cli/pkg/client/python.go
+++ b/cli/pkg/client/python.go
@@ -44,7 +44,8 @@ func AppSpecToPyTemplateData(appSpec schema.Application) (PySDKTemplateData, err
 
 func GeneratePython(fs afero.Fs, appSpec schema.Application, outputDir string) error {
 	if outputDir == "" {
-		outputDir = version.CommandName
+		// Add _gen suffix so the generated client doesn't shadow the 'suga' import from Pypi
+		outputDir = fmt.Sprintf("%s_gen", version.CommandName)
 	}
 
 	tmpl := template.Must(template.New("client").Parse(pyClientTemplate))


### PR DESCRIPTION
Fixes an issue where the generated client would shadow the 'suga' import from Pypi.

Appends a '_gen' suffix to the default output directory for generated Python clients.
