### PR TITLE
add conventional commit linting with scopes

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,15 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,55 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  plugins: [
+    {
+      rules: {
+        "scope-empty-for-type": ({ type, scope }) => {
+          // Allow empty scope for docs, ci, and chore commits
+          const typesAllowingEmptyScope = ["docs", "ci", "chore"];
+          if (typesAllowingEmptyScope.includes(type) && !scope) {
+            return [true];
+          }
+          // Require scope for other types
+          if (!typesAllowingEmptyScope.includes(type) && !scope) {
+            return [false, `scope is required for type '${type}'`];
+          }
+          return [true];
+        },
+      },
+    },
+  ],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "refactor",
+        "perf",
+        "test",
+        "ci",
+        "chore",
+        "revert",
+      ],
+    ],
+    "scope-enum": [
+      2,
+      "always",
+      [
+        "cli",
+        "client",
+        "server",
+        "runtime",
+        "engines",
+        "proto",
+        "docs",
+        "deps",
+        "ci",
+        "release",
+      ],
+    ],
+    "scope-empty-for-type": [2, "always"],
+  },
+};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -3,17 +3,14 @@ export default {
   plugins: [
     {
       rules: {
-        "scope-empty-for-type": ({ type, scope }) => {
-          // Allow empty scope for docs, ci, and chore commits
-          const typesAllowingEmptyScope = ["docs", "ci", "chore"];
-          if (typesAllowingEmptyScope.includes(type) && !scope) {
-            return [true];
-          }
-          // Require scope for other types
-          if (!typesAllowingEmptyScope.includes(type) && !scope) {
-            return [false, `scope is required for type '${type}'`];
-          }
-          return [true];
+        "scope-empty-for-type": (parsed, when = "always", allowed = ["docs", "ci", "chore"]) => {
+          const { type, scope } = parsed ?? {};
+          const isEmpty = !scope;
+          const allowEmptyForType = allowed.includes(type);
+          // When = "always": require scope for non-allowed types. "never" would disable requirement.
+          const requireScope = when !== "never" && !allowEmptyForType;
+          const pass = requireScope ? !isEmpty : true;
+          return [pass, pass ? undefined : `scope is required for type '${type}'`];
         },
       },
     },
@@ -50,6 +47,6 @@ export default {
         "release",
       ],
     ],
-    "scope-empty-for-type": [2, "always"],
+    "scope-empty-for-type": [2, "always", ["docs", "ci", "chore"]],
   },
 };


### PR DESCRIPTION
Sets up commit message linting to enforce conventional commits:
- Adds a workflow to lint commit messages on pull requests.
- Configures commitlint with conventional commits preset.
- Enforces scope requirements based on commit type.

closes NIT-197