### PR TITLE
fix(cli): adds SHA256 hash header to API requests

### DIFF
--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +13,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/do/v2"
 )
+
+// calculateSHA256 calculates the SHA256 hash of the given data and returns it as a hex string
+func calculateSHA256(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
 
 type TokenProvider interface {
 	// GetAccessToken returns the access token for the user
@@ -139,6 +147,7 @@ func (c *SugaApiClient) post(path string, requiresAuth bool, body []byte) (*http
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-amz-content-sha256", calculateSHA256(body))
 
 	return c.doRequestWithRetry(req, requiresAuth)
 }

--- a/cli/internal/workos/http/client.go
+++ b/cli/internal/workos/http/client.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,12 @@ import (
 )
 
 const DEFAULT_HOSTNAME = "api.workos.com"
+
+// calculateSHA256 calculates the SHA256 hash of the given data and returns it as a hex string
+func calculateSHA256(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
 
 // Errors
 type CodeExchangeError struct {
@@ -270,6 +278,7 @@ func (h *HttpClient) post(path string, body map[string]interface{}) (*http.Respo
 
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-amz-content-sha256", calculateSHA256(jsonBody))
 
 	return h.client.Do(req)
 }
@@ -473,6 +482,7 @@ func (c *HttpClient) PollDeviceTokenWithContext(ctx context.Context, deviceCode 
 
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-amz-content-sha256", calculateSHA256(jsonBody))
 
 	response, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Adds the `x-amz-content-sha256` header to API requests.

Fixes NIT-208
