### PR TITLE
fix(cli): fix login saying "logged in as " when user name not available

### DIFF
--- a/cli/pkg/app/auth.go
+++ b/cli/pkg/app/auth.go
@@ -30,7 +30,13 @@ func (c *AuthApp) Login() {
 		return
 	}
 
-	fmt.Printf("\n%s Logged in as %s\n", style.Green(icons.Check), style.Teal(user.FirstName))
+	// The user's name can be blank, so we use the email as a fallback
+	name := user.FirstName
+	if name == "" {
+		name = user.Email
+	}
+
+	fmt.Printf("\n%s Logged in as %s\n", style.Green(icons.Check), style.Teal(name))
 }
 
 // Logout handles the logout command logic


### PR DESCRIPTION
If the user hasn't set first name, the login command would say "✓ Logged in as ", this fix uses email if name is blank. e.g. "✓ Logged in as user@example.com"

Fixes: NIT-214
