### PR TITLE
feat(cli): add debug logging flag

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,12 +22,17 @@ func NewRootCmd(injector do.Injector) *cobra.Command {
 				return err
 			}
 
+			if debugFlag, _ := cmd.Flags().GetBool("debug"); debugFlag {
+				conf.SetDebug(true)
+			}
+
 			do.ProvideValue(injector, conf)
 			return nil
 		},
 	}
 
-	// Add commands that use the CLI struct methods
+	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug mode with verbose API request/response logging")
+
 	rootCmd.AddCommand(NewLoginCmd(injector))
 	rootCmd.AddCommand(NewLogoutCmd(injector))
 	rootCmd.AddCommand(NewAccessTokenCmd(injector))

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Config struct {
-	v   *viper.Viper `mapstructure:"-"`
-	Url string       `mapstructure:"url" desc:"The base URL of the Suga server (e.g., https://app.addsuga.com)"`
+	v     *viper.Viper `mapstructure:"-"`
+	Url   string       `mapstructure:"url" desc:"The base URL of the Suga server (e.g., https://app.addsuga.com)"`
+	Debug bool         `mapstructure:"debug" desc:"Enable debug mode with verbose logging"`
 }
 
 func (c *Config) FileUsed() string {
@@ -91,6 +92,10 @@ func (c *Config) SetSugaServerUrl(newUrl string) error {
 
 	c.Url = sugaUrl.String()
 	return nil
+}
+
+func (c *Config) SetDebug(debug bool) {
+	c.Debug = debug
 }
 
 func (c *Config) Save(global bool) error {

--- a/cli/internal/workos/workos.go
+++ b/cli/internal/workos/workos.go
@@ -52,7 +52,7 @@ func NewWorkOSAuth(inj do.Injector) (*WorkOSAuth, error) {
 			opts = append(opts, http.WithPort(pn))
 		}
 	}
-	httpClient := http.NewHttpClient("", opts...)
+	httpClient := http.NewHttpClient("", config, opts...)
 
 	tokenStore := do.MustInvokeAs[TokenStore](inj)
 


### PR DESCRIPTION
Adds a debug flag to enable verbose logging of API requests and responses.

This feature helps troubleshoot issues by providing detailed information about the communication between the CLI and the backend server.

The debug flag is added as a persistent flag to the root command, allowing it to be used with any subcommand.

The API client and the WorkOS client are updated to log requests and responses when the debug flag is enabled.
