### PR TITLE
ci: allow longer commit message lines

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -48,5 +48,9 @@ export default {
       ],
     ],
     "scope-empty-for-type": [2, "always", ["docs", "ci", "chore"]],
+    // Disable line length restrictions
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+    "header-max-length": [0],
   },
 };


### PR DESCRIPTION
The @commitlint/config-conventional rules are too restrictive on message line length, this removes those restrictions
