### PR TITLE
Improves error reporting for misconfigurations

### DIFF
--- a/engines/terraform/resource_handler.go
+++ b/engines/terraform/resource_handler.go
@@ -54,6 +54,9 @@ func (td *TerraformDeployment) processServiceIdentities(appSpec *app_spec_schema
 		if err != nil {
 			return nil, fmt.Errorf("could not find platform type for %s.%s: %w", serviceIntent.GetType(), serviceIntent.GetSubType(), err)
 		}
+		if spec == nil {
+			return nil, fmt.Errorf("platform returned nil blueprint for service %s with type %s.%s", intentName, serviceIntent.GetType(), serviceIntent.GetSubType())
+		}
 		plug, err := td.engine.resolvePlugin(spec.ResourceBlueprint)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes: NIT-252

Improves error reporting for platform misconfigurations, providing more context and preventing panics.

Specifically:
- Checks for nil `resourceSpec` and returns an error indicating a platform configuration issue.
- Checks for nil `IdentitiesBlueprint` before accessing `Identities`.
- Enhances the error message when a required identity is missing, clarifying if no identities are provided at all.
- Adds a check for nil blueprint from platform.

This change addresses a potential panic situation and provides clearer error messages to aid in debugging platform configuration issues.