### PR TITLE
fix(cli): Improves error handling and prevents null values

### DIFF
--- a/engines/terraform/resolve.go
+++ b/engines/terraform/resolve.go
@@ -88,7 +88,11 @@ func (td *TerraformDeployment) resolveTokensForModule(intentName string, resourc
 	for property, value := range resource.Properties {
 		resolvedValue, err := td.resolveValue(intentName, value)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to resolve property '%s' for intent '%s': %w", property, intentName, err)
+		}
+		// Skip nil values and empty strings
+		if resolvedValue == nil || (resolvedValue == "") {
+			continue
 		}
 		module.Set(jsii.String(property), resolvedValue)
 	}


### PR DESCRIPTION
Prevents setting null or undefined values on Terraform modules, ensuring only resolved values are applied, avoiding panics.

> This issue is noticable when setting the value of an array and then removing the value - the module then tries to apply "" as an array or map depending on the input type causing a panic.