### PR TITLE
ci(cli): publish the cli to `nitrictech/tap/suga`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,7 +47,7 @@ brews:
   - name: suga
     repository:
       owner: nitrictech
-      name: suga-homebrew-tap
+      name: homebrew-tap
     commit_author:
       name: nitric-bot
       email: maintainers@nitric.io


### PR DESCRIPTION
Fixes: NIT-248

This should safely publish the suga cli to the existing [tap repo](https://github.com/nitrictech/homebrew-tap), alongside the Nitric framework CLI. So that the documented install command works.

```bash
# Current install cmd (not working)
brew install nitrictech/tap/suga
```

Alternatively if we to use something like:

```bash
# Alternate install cmd
brew install nitrictech/suga/suga
```

We could rename the [suga-homebrew-tap](https://github.com/nitrictech/suga-homebrew-tap) repo to `homebrew-suga` and update Go Releaser to publish there instead.