### PR TITLE
docs: use lucide icons instead of font awesome

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -51,7 +51,7 @@ suga dev
     Use `suga new` to create projects from templates or `suga init` to add Suga
     to existing apps
   </Card>
-  <Card title="Visual Editor" icon="pen-to-square" href="/cli/edit">
+  <Card title="Visual Editor" icon="pencil-ruler" href="/cli/edit">
     Use `suga edit` to design your application architecture and configure
     deployment targets
   </Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,6 +7,9 @@
     "light": "#2BC65F",
     "dark": "#25B355"
   },
+  "icons": {
+    "library": "lucide"
+  },
   "favicon": "/favicon.svg",
   "navigation": {
     "tabs": [

--- a/docs/guides/add-suga.mdx
+++ b/docs/guides/add-suga.mdx
@@ -31,7 +31,7 @@ Suga helps you migrate existing applications to a cloud-agnostic architecture. W
 
   </Step>
 
-  <Step title="Configure Infrastructure" icon="gear">
+  <Step title="Configure Infrastructure" icon="cog">
     Open the Suga visual editor to design your infrastructure:
 
     ```bash title="Open Suga Editor" icon="pencil"

--- a/docs/guides/local-database-setup.mdx
+++ b/docs/guides/local-database-setup.mdx
@@ -50,7 +50,7 @@ Suga doesn't currently auto-provision databases for local development. This guid
 
     Verify it's running:
 
-    ```bash title="Verify Database" icon="check-circle"
+    ```bash title="Verify Database" icon="circle-check"
     docker compose ps
     ```
 
@@ -60,7 +60,7 @@ Suga doesn't currently auto-provision databases for local development. This guid
   <Step title="Configure Database in Suga">
     Open the Suga dashboard:
 
-    ```bash title="Open Suga Editor" icon="edit"
+    ```bash title="Open Suga Editor" icon="pencil-ruler"
     suga edit
     ```
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -173,7 +173,7 @@ Built by the team behind [Nitric](https://nitric.io), Suga incorporates lessons 
   <Card title="GitHub" icon="github" href="https://github.com/nitrictech/suga">
     View the source code and contribute to the project.
   </Card>
-  <Card title="Support" icon="question" href="mailto:support@addsuga.com">
+  <Card title="Support" icon="life-buoy" href="mailto:support@addsuga.com">
     Get help from our support team.
   </Card>
 </Columns>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,7 +37,7 @@ Deploy your first application on the Suga platform in just a few steps. The Suga
     ```
   </Step>
 
-  <Step title="Design Your Architecture" icon="pen-to-square">
+  <Step title="Design Your Architecture" icon="pencil-line">
     Log in and open the visual editor:
 
     ```bash title="Login to Suga" icon="user"


### PR DESCRIPTION
Replaces the Font Awesome icons (which is the default in Mintlify) with Lucide. This matches the icon set we use on the website and app.