### PR TITLE
fix(cli): add current org to the dev path params to skip org selection

### DIFF
--- a/cli/pkg/app/suga.go
+++ b/cli/pkg/app/suga.go
@@ -587,6 +587,7 @@ func (c *SugaApp) Edit() error {
 	devUrl := c.config.GetSugaServerUrl().JoinPath(currentTeam.Slug, "dev")
 	q := devUrl.Query()
 	q.Add("port", port)
+	q.Add("org_id", currentTeam.WorkOsID)
 	devUrl.RawQuery = q.Encode()
 
 	fmt.Println(tui.SugaIntro("Sync Port", port, "Dashboard", devUrl.String()))


### PR DESCRIPTION
https://linear.app/nitric/issue/NIT-255/running-suga-edit-while-logged-out-of-the-web-app-still-causes-org

With this platform change https://github.com/nitrictech/platform/pull/221