### PR TITLE
fix(cli): improves device authentication polling

### DIFF
--- a/cli/internal/workos/device.go
+++ b/cli/internal/workos/device.go
@@ -72,7 +72,7 @@ func (a *WorkOSAuth) performDeviceAuth() error {
 			select {
 			case <-ctx.Done():
 				return fmt.Errorf("device authorization timed out")
-			case <-time.After(time.Until(time.Now().Add(pollInterval))):
+			case <-time.After(pollInterval):
 				// Continue to poll
 			}
 

--- a/cli/internal/workos/device.go
+++ b/cli/internal/workos/device.go
@@ -84,8 +84,8 @@ func (a *WorkOSAuth) performDeviceAuth() error {
 			}
 
 			// Set the next poll time immediately to ensure consistent intervals
-			// This ensures we poll every 5 seconds regardless of request duration
 			// Add a small buffer to account for network latency and clock skew
+			// This ensures we never poll faster than every 5 seconds
 			const safetyBuffer = 100 * time.Millisecond
 			nextPollTime = time.Now().Add(currentInterval + safetyBuffer)
 


### PR DESCRIPTION
Ensures consistent polling intervals during device authentication by:

- Adding a safety buffer to account for network latency and clock skew.

Closes NIT-346
