### PR TITLE
fix(cli): add working_directory to service specs

### DIFF
--- a/cli/internal/simulation/service/service.go
+++ b/cli/internal/simulation/service/service.go
@@ -214,7 +214,7 @@ func (s *ServiceSimulation) Start(autoRestart bool) error {
 		srvCommand.Env = append(srvCommand.Env, fmt.Sprintf("PORT=%d", s.port))
 		srvCommand.Env = append(srvCommand.Env, fmt.Sprintf("SUGA_SERVICE_ADDRESS=localhost:%d", s.apiPort))
 
-		srvCommand.Dir = s.intent.Container.Docker.Context
+		srvCommand.Dir = s.intent.WorkingDir
 		srvCommand.Stdout = stdoutWriter
 		srvCommand.Stderr = stderrWriter
 

--- a/cli/pkg/schema/service.go
+++ b/cli/pkg/schema/service.go
@@ -1,9 +1,12 @@
 package schema
 
 type ServiceIntent struct {
-	Resource  `json:",inline" yaml:",inline"`
-	Env       map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	Container Container         `json:"container" yaml:"container" jsonschema:"oneof_required=container"`
+	Resource `json:",inline" yaml:",inline"`
+	Env      map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+
+	WorkingDir string `json:"working_directory,omitempty" yaml:"working_directory,omitempty"`
+
+	Container Container `json:"container" yaml:"container" jsonschema:"oneof_required=container"`
 
 	Dev *Dev `json:"dev,omitempty" yaml:"dev,omitempty"`
 

--- a/engines/terraform/deployment.go
+++ b/engines/terraform/deployment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"path"
 	"slices"
 
 	"github.com/aws/jsii-runtime-go"
@@ -195,7 +196,7 @@ func (td *TerraformDeployment) resolveService(name string, spec *app_spec_schema
 		}
 
 		imageVars = &map[string]interface{}{
-			"build_context": jsii.String(spec.Container.Docker.Context),
+			"build_context": jsii.String(path.Join(spec.WorkingDir, spec.Container.Docker.Context)),
 			"dockerfile":    jsii.String(spec.Container.Docker.Dockerfile),
 			"tag":           jsii.String(name),
 			"args":          args,


### PR DESCRIPTION
Fixes: NIT-285

Adds working_directory, for dev command (and combines with docker context, can remove this if we want to fully separate them).

This change should be backwards compatible with existing templates and configurations unless the dev command is running on a sub-directory  in which case it will require an update (I can't see that in our existing templates though)

