### PR TITLE
fix(engine): improves command handling and validation

### DIFF
--- a/runtime/start.go
+++ b/runtime/start.go
@@ -67,7 +67,16 @@ func Start(cmd string) {
 	}()
 
 	// Start the actual suga service
-	cmdParts := strings.Split(cmd, " ")
+	cmdParts := strings.Fields(cmd)
+	if len(cmdParts) == 0 {
+		log.Fatalf("failed to start service: Dockerfile must specify a CMD and/or ENTRYPOINT")
+	}
+
+	// Expand environment variables in each argument
+	for i := range cmdParts {
+		cmdParts[i] = os.ExpandEnv(cmdParts[i])
+	}
+
 	runCmd := exec.Command(cmdParts[0], cmdParts[1:]...)
 	runCmd.Env = os.Environ()
 	runCmd.Stdout = os.Stdout


### PR DESCRIPTION
  Service wrapper failed with `exec: no command` due to leading/trailing whitespace in the command
  string from Terraform's entrypoint/cmd concatenation.

  ### Solution
  - Replace `strings.Split(cmd, " ")` with `strings.Fields(cmd)` to properly handle whitespace
  - Add `os.ExpandEnv()` to expand environment variables like `$PORT` in CMD arguments
  - Improve error message when CMD/ENTRYPOINT is missing

  ### Examples
  - `CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]` ✅
  - `CMD ["node", "main.js"]` ✅
  - `ENTRYPOINT ["/main"]` ✅
  - `CMD ["uvicorn", "app:main", "--port", "$PORT"]` ✅ (expands at runtime)