### PR TITLE
fix(engine): trim leading whitespace from original command

### DIFF
--- a/engines/terraform/modules/image/main.tf
+++ b/engines/terraform/modules/image/main.tf
@@ -22,7 +22,7 @@ data "external" "inspect_base_image" {
 }
 
 locals {
-  original_command = "${data.external.inspect_base_image.result.entrypoint} ${data.external.inspect_base_image.result.cmd}"
+  original_command = trimspace("${data.external.inspect_base_image.result.entrypoint} ${data.external.inspect_base_image.result.cmd}")
   image_id         = var.image_id == null ? docker_image.base_service.name : var.image_id
 }
 


### PR DESCRIPTION
Ensures that the original command, constructed from the entrypoint and command of the base image, does not contain leading or trailing whitespace. 

This prevents potential issues when executing the command.