### PR TITLE
fix(engines): injects suga variable into infrastructure modules

### DIFF
--- a/engines/terraform/deployment.go
+++ b/engines/terraform/deployment.go
@@ -73,8 +73,15 @@ func (td *TerraformDeployment) resolveInfraResource(infraName string) (cdktf.Ter
 
 		td.createVariablesForIntent(infraName, resource)
 
+		sugaVar := map[string]any{
+			"stack_id": td.stackId.Result(),
+		}
+
 		td.terraformInfraResources[infraName] = cdktf.NewTerraformHclModule(td.stack, jsii.String(infraName), &cdktf.TerraformHclModuleConfig{
 			Source: jsii.String(pluginRef.Deployment.Terraform),
+			Variables: &map[string]interface{}{
+				"suga": sugaVar,
+			},
 		})
 	}
 


### PR DESCRIPTION
Adds the `suga` variable containing infrastructure name and stack ID to the Terraform module configuration.

Required to create unique names for these resources in their respective terraform module implementations.