### PR TITLE
fix(cli): python client address handling

### DIFF
--- a/cli/pkg/client/python_client_template
+++ b/cli/pkg/client/python_client_template
@@ -10,7 +10,7 @@ from suga.buckets import Bucket
 class SugaClient:
     def __init__(self):
         address = os.getenv("SUGA_SERVICE_ADDRESS")
-        if address == "":
+        if not address:
             address = "localhost:50051"
         
         self._channel = grpc.insecure_channel(address)


### PR DESCRIPTION
Ensures that the client functions correctly even if the environment variable is set to an empty value. (e.g. not set).